### PR TITLE
First-order terms and formulas

### DIFF
--- a/src/Errors.elm
+++ b/src/Errors.elm
@@ -1,5 +1,4 @@
 module Errors exposing (..)
-import Result
 
 {-| Like `Result.map2` but merges errors (which must be lists).
 -}
@@ -31,5 +30,13 @@ map f result =
     case result of
       Ok v -> Ok v
       Err es -> Err (List.map f es)
+
+{-| An instance of Haskell's mapM for Result.
+    Maps an operation that can fail over elements of a list,
+    returning either the left-most error or the list of good results.
+-}
+mapResult : (a -> Result x b) -> List a -> Result x (List b)
+mapResult f =
+  List.foldr (Result.map2 (::) << f) (Ok [])
 
 {- vim: set sw=2 ts=2 sts=2 et : -}

--- a/src/Formula.elm
+++ b/src/Formula.elm
@@ -313,6 +313,9 @@ formula =
             [ inContext "predicate arguments" args
             , succeed []
             ]
+    , lazy (\_ -> quantified ["∀", "\\A", "\\forall", "\\a"] ForAll)
+    -- keep \exists before \e
+    , lazy (\_ -> quantified ["∃", "\\E", "\\exists", "\\e"] Exists)
     , succeed Neg
         |. oneOfSymbols ["-", "¬", "~"]
         |. spaces
@@ -341,6 +344,14 @@ binary conn constructor =
   |= lazy (\_ -> formula)
   |. spaces
   |. symbol ")"
+
+quantified symbols constructor =
+  succeed constructor
+    |. oneOfSymbols symbols
+    |. spaces
+    |= lazy (\_ -> identifier)
+    |. spaces
+    |= lazy (\_ -> formula)
 
 args : Parser (List Term)
 args =

--- a/src/Formula.elm
+++ b/src/Formula.elm
@@ -396,21 +396,26 @@ strSigned sf =
     F f -> "F " ++ (strFormula f)
 
 strFormula f =
-  case f of
-    FT -> "True"
-    FF -> "False"
-    Atom p ts -> if List.isEmpty ts then
-                   p
-                 else
-                   p ++ strArgs ts
-    Neg f -> "¬" ++ (strFormula f)
-    Conj lf rf -> "(" ++ (strFormula lf) ++ "∧" ++ (strFormula rf) ++ ")"
-    Disj lf rf -> "(" ++ (strFormula lf) ++ "∨" ++ (strFormula rf) ++ ")"
-    Impl lf rf -> "(" ++ (strFormula lf) ++ "→" ++ (strFormula rf) ++ ")"
-    ForAll bv rf -> "∀" ++ bv ++ (strFormula rf)
-    Exists bv rf -> "∃" ++ bv ++ (strFormula rf)
+  let
+    strBinF lf c rf = "(" ++ strFormula lf ++ c ++ strFormula rf ++ ")"
+    strQF q bv f = q ++ bv ++ atomSpace f ++ strFormula f
+    atomSpace f = case f of
+        Atom _ _ -> " "
+        _ -> ""
+  in
+    case f of
+      FT -> "True"
+      FF -> "False"
+      Atom p [] -> p
+      Atom p ts -> p ++ strArgs ts
+      Neg f -> "¬" ++ strFormula f
+      Conj lf rf -> strBinF lf "∧" rf
+      Disj lf rf -> strBinF lf "∨" rf
+      Impl lf rf -> strBinF lf "→" rf
+      ForAll bv f -> strQF "∀" bv f
+      Exists bv f -> strQF "∃" bv f
 
-strArgs ts = "(" ++ (String.join "," <| List.map strTerm ts) ++ ")"
+strArgs ts = "(" ++ String.join "," (List.map strTerm ts) ++ ")"
 
 strTerm t =
   case t of

--- a/src/Formula.elm
+++ b/src/Formula.elm
@@ -307,7 +307,7 @@ formula : Parser Formula
 formula =
   oneOf
     [ succeed Atom
-        |= variable Char.isLower isIdentChar (Set.fromList [])
+        |= identifier
         |. spaces
         |= oneOf
             [ inContext "predicate arguments" args
@@ -362,7 +362,7 @@ nextArg =
 
 term : Parser Term
 term =
-  variable isLetter isIdentChar Set.empty |>
+  identifier |>
     Parser.andThen (\name ->
       oneOf
         [ succeed (\args -> Fun name args)
@@ -370,6 +370,8 @@ term =
         , succeed (Var name)
         ]
     )
+
+identifier = variable isLetter isIdentChar Set.empty
 
 oneOfSymbols syms =
   oneOf (List.map symbol syms)

--- a/src/Help.elm
+++ b/src/Help.elm
@@ -5,8 +5,8 @@ import Formula exposing (..)
 import Markdown
 
 
-fA = Atom "A"
-fB = Atom "B"
+fA = Atom "A" []
+fB = Atom "B" []
 
 alphas =
   [ T (Conj fA fB)


### PR DESCRIPTION
Groundwork for first-order terms and formulas (first part of #2):
- types,
- extensions of standard operations,
- parser
- syntactic operations (substitutions etc.).

Todo:
- [ ] Agree on syntax of atomic formulas
- [ ] Agree on quantifiers syntax
- [ ] Implement quantifiers parser
