### PR TITLE
Fix entering references #20

### DIFF
--- a/src/Tableau.elm
+++ b/src/Tableau.elm
@@ -132,18 +132,10 @@ rightSubtree t =
 
 strRefsToList : String -> List String
 strRefsToList str =
-    let
-        lst =
-            List.filter (\a -> a /= "") (String.split "," (String.replace " " "" str))
-    in
-    if String.right 1 str == "," then
-        List.append lst [ "" ]
-
-    else if String.left 1 str == "," then
-        "" :: lst
-
+    if String.isEmpty str then 
+        [] 
     else
-        lst
+        (String.split "," str)
 
 
 refsToString : List Ref -> String

--- a/src/Zipper.elm
+++ b/src/Zipper.elm
@@ -325,6 +325,7 @@ getRef z ref =
     { str = ref
     , up =
         ref
+            |> String.replace " " ""
             |> String.toInt
             |> Maybe.andThen (\a -> findAbove a z)
     }

--- a/src/Zipper.elm
+++ b/src/Zipper.elm
@@ -325,7 +325,7 @@ getRef z ref =
     { str = ref
     , up =
         ref
-            |> String.replace " " ""
+            |> String.trim
             |> String.toInt
             |> Maybe.andThen (\a -> findAbove a z)
     }


### PR DESCRIPTION
I didn't use parser, I think it's better to store and parse each reference string separately because of renumbering when adding or deleting nodes. If one of the references was invalid and the other valid, none of them would get parsed and the valid one couldn't be renumbered. The "Ref" structure is also used for closing references and would have to be handled separately.  
The current solution should work correctly after this change.