### PR TITLE
Fix HS rule validation depending on reference order

### DIFF
--- a/src/Validation/Rules/HS.elm
+++ b/src/Validation/Rules/HS.elm
@@ -23,6 +23,9 @@ getNewFormula f1 f2 =
             if b == c then
                 Ok (T (Impl a d))
 
+            else if d == a then
+                Ok (T (Impl c b))
+
             else
                 Err refStructureErr
 


### PR DESCRIPTION
HS validation no longer produces an error if the references are swapped